### PR TITLE
Migrate to Azul Metadata API

### DIFF
--- a/Casks/zulu-jdk12.rb
+++ b/Casks/zulu-jdk12.rb
@@ -1,9 +1,9 @@
 cask 'zulu-jdk12' do
 
     version '12.3.11,12.0.2'
-    sha256 '5b46f5a0ebc3bf9c98763a6ce173c9578db04ceadd352a7b25baeb59a8240bcb'
+    sha256 '5533220985805801ac1e3d44aeecef2f3ef36291b768415a298c0428d2ab4b89'
 
-    url 'https://cdn.azul.com/zulu/bin/zulu12.3.11_2-ca-jdk12.0.2-macosx_x64.dmg',
+    url 'https://cdn.azul.com/zulu/bin/zulu12.3.11-ca-jdk12.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/zulu-community/'
 
     depends_on macos: '>= :mojave'

--- a/updater/src/main/java/Main.java
+++ b/updater/src/main/java/Main.java
@@ -15,6 +15,7 @@ import retrofit2.Call;
 import retrofit2.Retrofit;
 import retrofit2.converter.moshi.MoshiConverterFactory;
 import retrofit2.http.GET;
+import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 public final class Main {
@@ -26,16 +27,16 @@ public final class Main {
     var caskDir = repoDir.resolve("Casks");
     var workflowsDir = repoDir.resolve(".github/workflows");
 
-    Map<Integer, BundleSet> jdkBundles = loadJdks();
-    for (var entry : jdkBundles.entrySet()) {
+    Map<Integer, PackageSet> jdkPackages = loadJdks();
+    for (var entry : jdkPackages.entrySet()) {
       int jdkVersion = entry.getKey();
-      var x86Bundle = entry.getValue().x86;
-      var armBundle = entry.getValue().arm;
+      var x86Package = entry.getValue().x86;
+      var armPackage = entry.getValue().arm;
 
-      if ("12.0.2".equals(x86Bundle.javaVersion()) && "12.3.11".equals(x86Bundle.zuluVersion())) {
+      if ("12.0.2".equals(x86Package.javaVersion()) && "12.3.11".equals(x86Package.zuluVersion())) {
         System.err.println(
             "Skipping JDK 12.0.2, because this version is changing back and forth between zulu12.3.11 and zulu12.3.11_2 => "
-                + x86Bundle);
+                + x86Package);
         continue;
       }
 
@@ -43,21 +44,21 @@ public final class Main {
       try (var w = buffer(sink(caskFile))) {
         w.writeUtf8("cask 'zulu-jdk" + jdkVersion + "' do\n\n");
 
-        if (armBundle != null) {
+        if (armPackage != null) {
           w.writeUtf8("  if Hardware::CPU.intel?\n");
         }
 
-        w.writeUtf8("    version '" + x86Bundle.caskVersion() + "'\n");
-        w.writeUtf8("    sha256 '" + x86Bundle.sha256_hash + "'\n\n");
-        w.writeUtf8("    url '" + x86Bundle.url + "',\n");
+        w.writeUtf8("    version '" + x86Package.caskVersion() + "'\n");
+        w.writeUtf8("    sha256 '" + x86Package.sha256_hash + "'\n\n");
+        w.writeUtf8("    url '" + x86Package.download_url + "',\n");
         w.writeUtf8("        referer: 'https://www.azul.com/downloads/zulu-community/'\n\n");
         w.writeUtf8("    depends_on macos: '>= :mojave'\n");
 
-        if (armBundle != null) {
+        if (armPackage != null) {
           w.writeUtf8("  else\n");
-          w.writeUtf8("    version '" + armBundle.caskVersion() + "'\n");
-          w.writeUtf8("    sha256 '" + armBundle.sha256_hash + "'\n\n");
-          w.writeUtf8("    url '" + armBundle.url + "',\n");
+          w.writeUtf8("    version '" + armPackage.caskVersion() + "'\n");
+          w.writeUtf8("    sha256 '" + armPackage.sha256_hash + "'\n\n");
+          w.writeUtf8("    url '" + armPackage.download_url + "',\n");
           w.writeUtf8("        referer: 'https://www.azul.com/downloads/zulu-community/'\n\n");
           w.writeUtf8("    depends_on macos: '>= :big_sur'\n");
           w.writeUtf8("  end\n");
@@ -88,7 +89,7 @@ public final class Main {
       w.writeUtf8("|--|--|--|--|\n");
 
       var sortedVersions =
-          jdkBundles.entrySet().stream()
+          jdkPackages.entrySet().stream()
               .map(e -> Map.entry(e.getKey(), e.getValue().x86().javaVersion()))
               .sorted(Entry.comparingByKey())
               .toList();
@@ -114,38 +115,36 @@ public final class Main {
     }
   }
 
-  private static Map<Integer, BundleSet> loadJdks() throws IOException {
+  private static Map<Integer, PackageSet> loadJdks() throws IOException {
     OkHttpClient.Builder builder = new OkHttpClient.Builder();
     builder.connectTimeout(30, TimeUnit.SECONDS);
     builder.readTimeout(30, TimeUnit.SECONDS);
     var okhttp = builder.build();
     var retrofit =
         new Retrofit.Builder()
-            .baseUrl("https://api.azul.com/zulu/download/community/v1.0/")
+            .baseUrl("https://api.azul.com/metadata/v1/zulu/packages/")
             .client(okhttp)
             .addConverterFactory(MoshiConverterFactory.create())
             .build();
-    var service = retrofit.create(ZuluDiscoveryService.class);
+    var service = retrofit.create(AzulMetadataService.class);
 
-    var jdkBundles = new LinkedHashMap<Integer, BundleSet>();
+    var jdkPackages = new LinkedHashMap<Integer, PackageSet>();
     int jdkVersion = MINIMUM_JDK_VERSION;
     while (true) {
-      var x86Response = service.latestBundle(jdkVersion, "x86").execute();
-      var x86Bundle = x86Response.isSuccessful() ? x86Response.body() : null;
-      System.out.println(jdkVersion + " x86 " + x86Bundle);
+      var x86PackageDetails = service.getPackageDetails(jdkVersion, "x86");
+      System.out.println(jdkVersion + " x86 " + x86PackageDetails);
 
-      var armResponse = service.latestBundle(jdkVersion, "arm").execute();
-      var armBundle = armResponse.isSuccessful() ? armResponse.body() : null;
-      System.out.println(jdkVersion + " ARM " + armBundle);
+      var armPackageDetails = service.getPackageDetails(jdkVersion, "arm");
+      System.out.println(jdkVersion + " ARM " + armPackageDetails);
 
-      if (x86Bundle == null) {
-        if (armBundle == null) {
+      if (x86PackageDetails == null) {
+        if (armPackageDetails == null) {
           break;
         }
         throw new IllegalStateException("JDK " + jdkVersion + " missing x86 arch");
       }
 
-      jdkBundles.put(jdkVersion, new BundleSet(x86Bundle, armBundle));
+      jdkPackages.put(jdkVersion, new PackageSet(x86PackageDetails, armPackageDetails));
       jdkVersion++;
     }
 
@@ -153,11 +152,10 @@ public final class Main {
     okhttp.dispatcher().executorService().shutdown();
     okhttp.connectionPool().evictAll();
 
-    return jdkBundles;
+    return jdkPackages;
   }
 
-  public record Bundle(
-      String url, String sha256_hash, List<Integer> java_version, List<Integer> zulu_version) {
+  public record Package(String package_uuid, String sha256_hash, String download_url, List<Integer> java_version, List<Integer> distro_version) {
     String caskVersion() {
       var zuluString = zuluVersion();
       var javaString = javaVersion();
@@ -169,20 +167,35 @@ public final class Main {
     }
 
     String zuluVersion() {
-      var zuluString = zulu_version.stream().map(String::valueOf).collect(joining("."));
-      if (zulu_version.size() > 3 && zuluString.endsWith(".0")) {
+      var zuluString = distro_version.stream().map(String::valueOf).collect(joining("."));
+      if (distro_version.size() > 3 && zuluString.endsWith(".0")) {
         zuluString = zuluString.substring(0, zuluString.length() - 2);
       }
       return zuluString;
     }
   }
 
-  record BundleSet(Bundle x86, Bundle arm) {}
+  record PackageSet(Package x86, Package arm) {}
 
-  interface ZuluDiscoveryService {
-    @GET("bundles/latest/?os=macos&ext=dmg&bundle_type=jdk&javafx=false&release_status=ga")
-    Call<Bundle> latestBundle(
-        @Query("java_version") int version, @Query("arch") String architecture);
+  public interface AzulMetadataService {
+    @GET("?availability_type=ca&os=macos&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&release_status=ga&latest=true")
+    Call<List<Package>> latestPackages(@Query("java_version") int version, @Query("arch") String architecture);
+
+    @GET("{package_uuid}")
+    Call<Package> packageDetails(@Path("package_uuid") String packageUUID);
+
+    default Package getPackageDetails(int version, String architecture) throws IOException {
+      var response = this.latestPackages(version, architecture).execute();
+      var latestPackages = response.isSuccessful() ? response.body() : null;
+
+      if (latestPackages == null || latestPackages.isEmpty()) return null;
+
+      // Data are sorted, with the newest packages being returned first.
+      var latestPackage = latestPackages.get(0);
+
+      var packageDetailsResponse = this.packageDetails(latestPackage.package_uuid).execute();
+      return packageDetailsResponse.isSuccessful() ? packageDetailsResponse.body() : null;
+    }
   }
 
   private static final int MINIMUM_JDK_VERSION = 7;

--- a/updater/src/main/java/Main.java
+++ b/updater/src/main/java/Main.java
@@ -148,7 +148,12 @@ public final class Main {
     return jdkPackages;
   }
 
-  public record Package(String package_uuid, String sha256_hash, String download_url, List<Integer> java_version, List<Integer> distro_version) {
+  public record Package(
+      String package_uuid,
+      String sha256_hash,
+      String download_url,
+      List<Integer> java_version,
+      List<Integer> distro_version) {
     String caskVersion() {
       var zuluString = zuluVersion();
       var javaString = javaVersion();
@@ -171,8 +176,10 @@ public final class Main {
   record PackageSet(Package x86, Package arm) {}
 
   public interface AzulMetadataService {
-    @GET("?availability_type=ca&os=macos&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&release_status=ga&latest=true")
-    Call<List<Package>> latestPackages(@Query("java_version") int version, @Query("arch") String architecture);
+    @GET(
+        "?availability_type=ca&os=macos&archive_type=dmg&java_package_type=jdk&javafx_bundled=false&release_status=ga&latest=true")
+    Call<List<Package>> latestPackages(
+        @Query("java_version") int version, @Query("arch") String architecture);
 
     @GET("{package_uuid}")
     Call<Package> packageDetails(@Path("package_uuid") String packageUUID);

--- a/updater/src/main/java/Main.java
+++ b/updater/src/main/java/Main.java
@@ -33,13 +33,6 @@ public final class Main {
       var x86Package = entry.getValue().x86;
       var armPackage = entry.getValue().arm;
 
-      if ("12.0.2".equals(x86Package.javaVersion()) && "12.3.11".equals(x86Package.zuluVersion())) {
-        System.err.println(
-            "Skipping JDK 12.0.2, because this version is changing back and forth between zulu12.3.11 and zulu12.3.11_2 => "
-                + x86Package);
-        continue;
-      }
-
       var caskFile = caskDir.resolve("zulu-jdk" + jdkVersion + ".rb");
       try (var w = buffer(sink(caskFile))) {
         w.writeUtf8("cask 'zulu-jdk" + jdkVersion + "' do\n\n");


### PR DESCRIPTION
### Description

Migrates updater from using the Zulu OpenJDK Discovery API to the Azul Metadata API.

[Migrate from Zulu OpenJDK Discovery API to Azul Metadata API](https://docs.azul.com/core/metadata-api-migration#response-differences)

### Changes
* Rename all references of 'bundle' to 'package' to be in line with API documentation.
* The base URL of the api changed from `https://api.azul.com/zulu/download/community/v1.0/` to `https://api.azul.com/metadata/v1/zulu/packages/`
* `/bundles/latest` is no longer available
  - Now we fetch `/packages/` with `latest=true` param and get the first package in the list (From article: Data are sorted, with the newest packages being returned first.)
* Other param changes:
  - `ext=dmg` -> `archive_type=dmg`
  - `bundle_type=jdk` -> `java_package_type=jdk`
  - `javafx=false` -> `javafx_bundled=false`
  - Added `availability_type=ca` to since `/community/` is no longer part of the path
* Return field changes:
  - `url` -> `download_url`
  - `zulu_version` -> `distro_version`
* Add extra request to `/packages/{package_uuid}` as the `/packages` endpoint does not returns the SHA256 hash.

### Possible Improvements

There are some aspects we could change which I would like some feedback on.

**Consolidate all per-package requests into a single request**
Since `latest` is now a param and `/packages` returns a list we could do an initial request without `java_version` and `arch` to get a list the all the latest packages for all versions and architectures to avoid having to make individual requests. While `/packages` also no longer specifies the architecture we can get the architecture from `/packages/{package_uuid}` which we fetch for the hash anyways.

The only odd thing I noticed is that Java 7 and Java 8 have multiple packages marked as latest and I'm not sure how that should be interpreted. (For example `8.0.372`, `8.0.201` and `8.0.163` each have packages marked as "latest"). We could just use the order of the response as the migration article above does specify that "newest packages being returned first."

This could offset the extra requests we have to make now to get the hash.

**Remove 12.0.2 skip**
I saw the weird quirk with 12.0.2 and checked out the version on the new API and while there are two packages with that version only one of them is marked as "latest" so we could remove skip and just use that one in line with the other versions? (The latest one is zulu12.3.11 without _2)

### Testing
Running the updater after the changes and deleting the casks produces identical `.rb` files as ones present before.