### PR TITLE
Move to macOS 13

### DIFF
--- a/.github/workflows/jdk10.yml
+++ b/.github/workflows/jdk10.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk11.yml
+++ b/.github/workflows/jdk11.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk13.yml
+++ b/.github/workflows/jdk13.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk14.yml
+++ b/.github/workflows/jdk14.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk15.yml
+++ b/.github/workflows/jdk15.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk16.yml
+++ b/.github/workflows/jdk16.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk17.yml
+++ b/.github/workflows/jdk17.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk18.yml
+++ b/.github/workflows/jdk18.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk19.yml
+++ b/.github/workflows/jdk19.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk21.yml
+++ b/.github/workflows/jdk21.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk22.yml
+++ b/.github/workflows/jdk22.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk23.yml
+++ b/.github/workflows/jdk23.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk7.yml
+++ b/.github/workflows/jdk7.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk8.yml
+++ b/.github/workflows/jdk8.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/.github/workflows/jdk9.yml
+++ b/.github/workflows/jdk9.yml
@@ -23,8 +23,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1

--- a/updater/src/main/java/Main.java
+++ b/updater/src/main/java/Main.java
@@ -243,8 +243,8 @@ jobs:
         os:
           # macos-latest is based on arm64.
           - macos-latest
-          # macos-12 is based on x64.
-          - macos-12
+          # macos-13 is based on x64.
+          - macos-13
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1


### PR DESCRIPTION
macOS 12 runners are deprecated.

https://github.com/actions/runner-images?tab=readme-ov-file#available-images