### PR TITLE
Remove pre-Catalina references

### DIFF
--- a/Casks/zulu-jdk10.rb
+++ b/Casks/zulu-jdk10.rb
@@ -6,7 +6,6 @@ cask 'zulu-jdk10' do
     url 'https://cdn.azul.com/zulu/bin/zulu10.3.5-ca-jdk10.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
 
   name 'Azul Zulu® JDK 10'
   homepage 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'

--- a/Casks/zulu-jdk11.rb
+++ b/Casks/zulu-jdk11.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk11' do
     url 'https://cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '11.84.17,11.0.29'
@@ -16,7 +15,6 @@ cask 'zulu-jdk11' do
     url 'https://cdn.azul.com/zulu/bin/zulu11.84.17-ca-jdk11.0.29-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 11'

--- a/Casks/zulu-jdk12.rb
+++ b/Casks/zulu-jdk12.rb
@@ -6,7 +6,6 @@ cask 'zulu-jdk12' do
     url 'https://cdn.azul.com/zulu/bin/zulu12.3.11_2-ca-jdk12.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
 
   name 'Azul Zulu® JDK 12'
   homepage 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'

--- a/Casks/zulu-jdk13.rb
+++ b/Casks/zulu-jdk13.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk13' do
     url 'https://cdn.azul.com/zulu/bin/zulu13.54.17-ca-jdk13.0.14-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '13.54.17,13.0.14'
@@ -16,7 +15,6 @@ cask 'zulu-jdk13' do
     url 'https://cdn.azul.com/zulu/bin/zulu13.54.17-ca-jdk13.0.14-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 13'

--- a/Casks/zulu-jdk14.rb
+++ b/Casks/zulu-jdk14.rb
@@ -6,7 +6,6 @@ cask 'zulu-jdk14' do
     url 'https://cdn.azul.com/zulu/bin/zulu14.29.23-ca-jdk14.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
 
   name 'Azul Zulu® JDK 14'
   homepage 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'

--- a/Casks/zulu-jdk15.rb
+++ b/Casks/zulu-jdk15.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk15' do
     url 'https://cdn.azul.com/zulu/bin/zulu15.46.17-ca-jdk15.0.10-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '15.46.17,15.0.10'
@@ -16,7 +15,6 @@ cask 'zulu-jdk15' do
     url 'https://cdn.azul.com/zulu/bin/zulu15.46.17-ca-jdk15.0.10-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 15'

--- a/Casks/zulu-jdk16.rb
+++ b/Casks/zulu-jdk16.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk16' do
     url 'https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '16.32.15,16.0.2'
@@ -16,7 +15,6 @@ cask 'zulu-jdk16' do
     url 'https://cdn.azul.com/zulu/bin/zulu16.32.15-ca-jdk16.0.2-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 16'

--- a/Casks/zulu-jdk17.rb
+++ b/Casks/zulu-jdk17.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk17' do
     url 'https://cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '17.62.17,17.0.17'
@@ -16,7 +15,6 @@ cask 'zulu-jdk17' do
     url 'https://cdn.azul.com/zulu/bin/zulu17.62.17-ca-jdk17.0.17-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 17'

--- a/Casks/zulu-jdk18.rb
+++ b/Casks/zulu-jdk18.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk18' do
     url 'https://cdn.azul.com/zulu/bin/zulu18.32.13-ca-jdk18.0.2.1-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '18.32.13,18.0.2.1'
@@ -16,7 +15,6 @@ cask 'zulu-jdk18' do
     url 'https://cdn.azul.com/zulu/bin/zulu18.32.13-ca-jdk18.0.2.1-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 18'

--- a/Casks/zulu-jdk19.rb
+++ b/Casks/zulu-jdk19.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk19' do
     url 'https://cdn.azul.com/zulu/bin/zulu19.32.13-ca-jdk19.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '19.32.13,19.0.2'
@@ -16,7 +15,6 @@ cask 'zulu-jdk19' do
     url 'https://cdn.azul.com/zulu/bin/zulu19.32.13-ca-jdk19.0.2-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 19'

--- a/Casks/zulu-jdk20.rb
+++ b/Casks/zulu-jdk20.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk20' do
     url 'https://cdn.azul.com/zulu/bin/zulu20.32.11_1-ca-jdk20.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '20.32.11,20.0.2'
@@ -16,7 +15,6 @@ cask 'zulu-jdk20' do
     url 'https://cdn.azul.com/zulu/bin/zulu20.32.11_1-ca-jdk20.0.2-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 20'

--- a/Casks/zulu-jdk21.rb
+++ b/Casks/zulu-jdk21.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk21' do
     url 'https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '21.46.19,21.0.9'
@@ -16,7 +15,6 @@ cask 'zulu-jdk21' do
     url 'https://cdn.azul.com/zulu/bin/zulu21.46.19-ca-jdk21.0.9-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 21'

--- a/Casks/zulu-jdk22.rb
+++ b/Casks/zulu-jdk22.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk22' do
     url 'https://cdn.azul.com/zulu/bin/zulu22.32.15-ca-jdk22.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '22.32.15,22.0.2'
@@ -16,7 +15,6 @@ cask 'zulu-jdk22' do
     url 'https://cdn.azul.com/zulu/bin/zulu22.32.15-ca-jdk22.0.2-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 22'

--- a/Casks/zulu-jdk23.rb
+++ b/Casks/zulu-jdk23.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk23' do
     url 'https://cdn.azul.com/zulu/bin/zulu23.32.11-ca-jdk23.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '23.32.11,23.0.2'
@@ -16,7 +15,6 @@ cask 'zulu-jdk23' do
     url 'https://cdn.azul.com/zulu/bin/zulu23.32.11-ca-jdk23.0.2-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 23'

--- a/Casks/zulu-jdk24.rb
+++ b/Casks/zulu-jdk24.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk24' do
     url 'https://cdn.azul.com/zulu/bin/zulu24.32.13-ca-jdk24.0.2-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '24.32.13,24.0.2'
@@ -16,7 +15,6 @@ cask 'zulu-jdk24' do
     url 'https://cdn.azul.com/zulu/bin/zulu24.32.13-ca-jdk24.0.2-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 24'

--- a/Casks/zulu-jdk25.rb
+++ b/Casks/zulu-jdk25.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk25' do
     url 'https://cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '25.30.17,25.0.1'
@@ -16,7 +15,6 @@ cask 'zulu-jdk25' do
     url 'https://cdn.azul.com/zulu/bin/zulu25.30.17-ca-jdk25.0.1-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 25'

--- a/Casks/zulu-jdk7.rb
+++ b/Casks/zulu-jdk7.rb
@@ -6,7 +6,6 @@ cask 'zulu-jdk7' do
     url 'https://cdn.azul.com/zulu/bin/zulu7.56.0.11-ca-jdk7.0.352-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
 
   name 'Azul Zulu® JDK 7'
   homepage 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'

--- a/Casks/zulu-jdk8.rb
+++ b/Casks/zulu-jdk8.rb
@@ -7,7 +7,6 @@ cask 'zulu-jdk8' do
     url 'https://cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
   end
   on_arm do
     version '8.90.0.19,8.0.472'
@@ -16,7 +15,6 @@ cask 'zulu-jdk8' do
     url 'https://cdn.azul.com/zulu/bin/zulu8.90.0.19-ca-jdk8.0.472-macosx_aarch64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :big_sur'
   end
 
   name 'Azul Zulu® JDK 8'

--- a/Casks/zulu-jdk9.rb
+++ b/Casks/zulu-jdk9.rb
@@ -6,7 +6,6 @@ cask 'zulu-jdk9' do
     url 'https://cdn.azul.com/zulu/bin/zulu9.0.7.1-ca-jdk9.0.7-macosx_x64.dmg',
         referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'
 
-    depends_on macos: '>= :mojave'
 
   name 'Azul Zulu® JDK 9'
   homepage 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'

--- a/Casks/zulu-mc.rb
+++ b/Casks/zulu-mc.rb
@@ -10,8 +10,6 @@ cask 'zulu-mc' do
     url "https://cdn.azul.com/zmc/bin/zmc#{version}-macos_x64.tar.gz",
         referer: 'https://www.azul.com/products/components/azul-mission-control/'
 
-    depends_on macos: '>= :mojave'
-
     app "zmc#{version}-macos_x64/Azul Mission Control.app"
   end
   on_arm do
@@ -20,8 +18,6 @@ cask 'zulu-mc' do
 
     url "https://cdn.azul.com/zmc/bin/zmc#{version}-macos_aarch64.tar.gz",
         referer: 'https://www.azul.com/products/components/azul-mission-control/'
-
-    depends_on macos: '>= :big_sur'
 
     app "zmc#{version}-macos_aarch64/Azul Mission Control.app"
   end

--- a/updater/src/main/java/Main.java
+++ b/updater/src/main/java/Main.java
@@ -66,7 +66,6 @@ public final class Main {
         w.writeUtf8("    url '" + x86Package.download_url + "',\n");
         w.writeUtf8(
             "        referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'\n\n");
-        w.writeUtf8("    depends_on macos: '>= :mojave'\n");
 
         if (armPackage != null) {
           w.writeUtf8("  end\n");
@@ -76,7 +75,6 @@ public final class Main {
           w.writeUtf8("    url '" + armPackage.download_url + "',\n");
           w.writeUtf8(
               "        referer: 'https://www.azul.com/downloads/?os=macos&package=jdk#zulu'\n\n");
-          w.writeUtf8("    depends_on macos: '>= :big_sur'\n");
           w.writeUtf8("  end\n");
         }
 


### PR DESCRIPTION
Fixes the warnings:

```
Warning: Calling `depends_on macos: :mojave` is deprecated! There is no replacement.
Please report this issue to the mdogan/homebrew-zulu tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/mdogan/homebrew-zulu/Casks/zulu-jdk10.rb:9

Warning: Calling `depends_on macos: :mojave` is deprecated! There is no replacement.
Please report this issue to the mdogan/homebrew-zulu tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/mdogan/homebrew-zulu/Casks/zulu-jdk12.rb:9

Warning: Calling `depends_on macos: :mojave` is deprecated! There is no replacement.
Please report this issue to the mdogan/homebrew-zulu tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/mdogan/homebrew-zulu/Casks/zulu-jdk14.rb:9

Warning: Calling `depends_on macos: :mojave` is deprecated! There is no replacement.
Please report this issue to the mdogan/homebrew-zulu tap (not Homebrew/* repositories):
  /opt/homebrew/Library/Taps/mdogan/homebrew-zulu/Casks/zulu-jdk9.rb:9
```

Refs https://github.com/Homebrew/homebrew-cask/pull/228165.