### PR TITLE
Try macos-26-intel runners

### DIFF
--- a/.github/workflows/reusable-cask-checks.yml
+++ b/.github/workflows/reusable-cask-checks.yml
@@ -15,7 +15,7 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
         os:
           - macos-latest # Based on arm64.
-          - macos-15-intel # Based on x64.
+          - macos-26-intel # Based on x64.
     runs-on: ${{ matrix.os }}
     env:
       HOMEBREW_COLOR: 1


### PR DESCRIPTION
https://github.blog/changelog/2026-02-26-macos-26-is-now-generally-available-for-github-hosted-runners/